### PR TITLE
feat: expose azure_storage_dns_suffix config flag for Azure Stack Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ And then execute:
       type azure-storage-append-blob
 
       azure_cloud                       <azure cloud environment>
+      azure_storage_dns_suffix          <your azure storage dns suffix> # only used for Azure Stack Cloud
       azure_storage_account             <your azure storage account>
       azure_storage_access_key          <your azure storage access key> # leave empty to use MSI
       azure_storage_connection_string   <your azure storage connection string> # leave empty to use MSI
@@ -58,6 +59,12 @@ And then execute:
 Default: `AZUREPUBLICCLOUD`
 
 Cloud environment used to determine the storage endpoint suffix to use, see [here](https://github.com/Azure/go-autorest/blob/master/autorest/azure/environments.go).
+
+Use `AZURESTACKCLOUD` for Azure Stack Cloud.
+
+### `azure_storage_dns_suffix` (Required only for Azure Stack Cloud)
+
+Your Azure Storage endpoint suffix. This can be retrieved from Azure Storage connection string, `EndpointSuffix` section.
 
 ### `azure_storage_account` (Required)
 

--- a/lib/fluent/plugin/out_azure-storage-append-blob.rb
+++ b/lib/fluent/plugin/out_azure-storage-append-blob.rb
@@ -36,6 +36,7 @@ module Fluent
       config_param :azure_storage_account, :string, default: nil
       config_param :azure_storage_access_key, :string, default: nil, secret: true
       config_param :azure_storage_connection_string, :string, default: nil, secret: true
+      config_param :azure_storage_dns_suffix, :string, default: nil
       config_param :azure_storage_sas_token, :string, default: nil, secret: true
       config_param :azure_cloud, :string, default: 'AZUREPUBLICCLOUD'
       config_param :azure_msi_client_id, :string, default: nil
@@ -75,9 +76,15 @@ module Fluent
                          end
                        end
 
-        @azure_storage_dns_suffix = @storage_endpoint_mapping[@azure_cloud]
-        if @azure_storage_dns_suffix.nil?
-          raise ConfigError 'azure_cloud invalid, must be either of AZURECHINACLOUD, AZUREGERMANCLOUD, AZUREPUBLICCLOUD, AZUREUSGOVERNMENTCLOUD'
+        if @azure_cloud == 'AZURESTACKCLOUD'
+          if @azure_storage_dns_suffix.nil?
+            raise ConfigError, 'azure_storage_dns_suffix invalid, must not be empty for AZURESTACKCLOUD'
+          end
+        else
+          @azure_storage_dns_suffix = @storage_endpoint_mapping[@azure_cloud]
+          if @azure_storage_dns_suffix.nil?
+            raise ConfigError, 'azure_cloud invalid, must be either of AZURECHINACLOUD, AZUREGERMANCLOUD, AZUREPUBLICCLOUD, AZUREUSGOVERNMENTCLOUD, AZURESTACKCLOUD'
+          end
         end
 
         if (@azure_storage_access_key.nil? || @azure_storage_access_key.empty?) &&


### PR DESCRIPTION
- Expose azure_storage_dns_suffix config flag for Azure Stack Cloud since each Azure Stack Cloud environment has different storage endpoints.
- Add unit tests to cover the new logic.
- Modify the documentation accordingly.

[What is Azure Stack?](https://docs.microsoft.com/en-us/azure-stack/operator/azure-stack-overview?view=azs-2008)